### PR TITLE
Force emscripten to wrap lines at 120 chars for now

### DIFF
--- a/STDLogSink.cpp
+++ b/STDLogSink.cpp
@@ -46,6 +46,7 @@ STDLogSink::STDLogSink(Severity min_severity)
 {
 	//Get the current display terminal width
 #ifndef _WIN32
+#ifndef __EMSCRIPTEN__
 	if(isatty(STDOUT_FILENO))
 	{
 		struct winsize w;
@@ -56,6 +57,9 @@ STDLogSink::STDLogSink(Severity min_severity)
 	{
 		m_termWidth = 120;	//reasonable default width for file logging
 	}
+#else
+	m_termWidth = 120;	//for now, force emscripten to always 120 char wrapping
+#endif
 #else
 	CONSOLE_SCREEN_BUFFER_INFO csbi;
 	GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);


### PR DESCRIPTION
Somehow emscripten isn't failing the isatty/ioctl, but is returning 0 or
something. Hack it to be 120 for now. Eventually I would like something
like CallbackLogSink