### PR TITLE
Fixed logging library not being compiled as shared lib on Win32

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,19 @@
 # CMake build script for logtools.
 # Intended to be integrated into a larger project, not built standalone.
 
+if(WIN32)
+add_library(log SHARED
+	log.cpp
+	ColoredSTDLogSink.cpp
+	STDLogSink.cpp
+	FILELogSink.cpp)
+else()
 add_library(log STATIC
 	log.cpp
 	ColoredSTDLogSink.cpp
 	STDLogSink.cpp
 	FILELogSink.cpp)
+endif()
 
 target_include_directories(log
 	PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
Forgot to push the changes to logtools.