### PR TITLE
CMakeLists: on Windows, install liblog.dll and liblog.dll.a

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(log SHARED
 	ColoredSTDLogSink.cpp
 	STDLogSink.cpp
 	FILELogSink.cpp)
+install(TARGETS log LIBRARY)
 else()
 add_library(log STATIC
 	log.cpp


### PR DESCRIPTION
As discussed in azonenberg/scopehal-apps#355.