### PR TITLE
Remove unneeded legacy MinGW include

### DIFF
--- a/log.h
+++ b/log.h
@@ -34,10 +34,6 @@
 
 #if defined(__MINGW32__)
 #undef ERROR
-#if !defined(__WINPTHREADS_VERSION)
-// Include mingw-std-threads extra header
-#include <mingw.mutex.h>
-#endif
 #endif
 
 /**


### PR DESCRIPTION
This include is no longer needed with current versions of MinGW/MSYS2, and will prevent compiling on MSYS2-CLANG64 and MSVC.