### PR TITLE
Un-inline for Win32 compatibility

### DIFF
--- a/log.cpp
+++ b/log.cpp
@@ -68,6 +68,9 @@ string LogSink::vstrprintf(const char* format, va_list va)
 	return ret;
 }
 
+string LogSink::GetIndentString()
+	{ return std::string(m_indentSize * g_logIndentLevel, ' '); }
+
 /**
 	@brief Wraps long lines and adds indentation as needed
  */
@@ -122,6 +125,18 @@ string LogSink::WrapString(string str)
  */
 void LogSink::PreprocessLine(string& /*line*/)
 {
+}
+
+
+LogIndenter::LogIndenter()
+{
+	//no mutexing needed b/c thread local
+	g_logIndentLevel ++;
+}
+
+LogIndenter::~LogIndenter()
+{
+	g_logIndentLevel --;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/log.h
+++ b/log.h
@@ -79,8 +79,7 @@ public:
 		Each log message printed is prefixed with (indentLevel * indentSize) space characters.
 		No parsing of newline etc characters is performed.
 	 */
-	std::string GetIndentString()
-	{ return std::string(m_indentSize * g_logIndentLevel, ' '); }
+	std::string GetIndentString();
 
 	virtual void Log(Severity severity, const std::string &msg) = 0;
 	virtual void Log(Severity severity, const char *format, va_list va) = 0;
@@ -165,16 +164,9 @@ extern std::set<std::string> g_trace_filters;
 class LogIndenter
 {
 public:
-	LogIndenter()
-	{
-		//no mutexing needed b/c thread local
-		g_logIndentLevel ++;
-	}
+	LogIndenter();
 
-	~LogIndenter()
-	{
-		g_logIndentLevel --;
-	}
+	~LogIndenter();
 };
 
 /**


### PR DESCRIPTION
Win32 does not allow accessing thread-local variables across shared library boundaries. See https://github.com/msys2/MINGW-packages/pull/16378#issuecomment-1481002915 for more details. This breaks build on MSYS2-CLAN64 (as well as MSVC). This commit un-inlines the code accessing thread-local variables, fixing build.