### PR TITLE
Fix building using MSVC - obvious build errors

### DIFF
--- a/log.h
+++ b/log.h
@@ -46,6 +46,13 @@
 #undef ERROR
 #endif
 
+#if defined(_MSC_VER)
+// MSVC
+#include <thread>
+#undef ERROR
+#define __thread __declspec(thread)
+#endif
+
 /**
 	@brief		Severity of a logging message
 	@ingroup	liblog


### PR DESCRIPTION
MSVC also requires `#undef ERROR`

The decorator for thread-local variables is different on Win32, so hijack `__thread` with a `#define`