### PR TITLE
MSVC symbol decorators

### DIFF
--- a/log.cpp
+++ b/log.cpp
@@ -44,7 +44,7 @@ using namespace std;
 	@brief		Mutex for serializing access to global logging state
 	@ingroup	logtools
  */
-mutex g_log_mutex;
+EXPORT_SYMBOL mutex g_log_mutex;
 
 /**
 	@brief		The current indentation level
@@ -59,21 +59,21 @@ __thread unsigned int g_logIndentLevel = 0;
 
 	@ingroup	logtools
  */
-vector<unique_ptr<LogSink>> g_log_sinks;
+EXPORT_SYMBOL vector<unique_ptr<LogSink>> g_log_sinks;
 
 /**
 	@brief		If set, STDLogSink will only write to stdout even for error/warning severity and never use stderr
 
 	@ingroup	logtools
  */
-bool g_logToStdoutAlways = false;
+EXPORT_SYMBOL bool g_logToStdoutAlways = false;
 
 /**
 	@brief		Set of classes or class::function for high verbosity trace messages
 
 	@ingroup	logtools
  */
-set<string> g_trace_filters;
+EXPORT_SYMBOL set<string> g_trace_filters;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // String formatting

--- a/log.h
+++ b/log.h
@@ -51,6 +51,11 @@
 #include <thread>
 #undef ERROR
 #define __thread __declspec(thread)
+#define EXPORT_SYMBOL __declspec(dllexport)
+#define IMPORT_SYMBOL _declspec(dllimport)
+#else
+#define EXPORT_SYMBOL
+#define IMPORT_SYMBOL
 #endif
 
 /**
@@ -84,7 +89,7 @@ extern __thread unsigned int g_logIndentLevel;
 	@brief		Base class for all log sinks
 	@ingroup	liblog
  */
-class LogSink
+class EXPORT_SYMBOL LogSink
 {
 public:
 	LogSink(Severity min_severity = Severity::VERBOSE)
@@ -135,7 +140,7 @@ protected:
 	@brief A log sink writing to stdout/stderr depending on severity
 	@ingroup	liblog
  */
-class STDLogSink : public LogSink
+class EXPORT_SYMBOL STDLogSink : public LogSink
 {
 public:
 	STDLogSink(Severity min_severity = Severity::VERBOSE);
@@ -152,7 +157,7 @@ protected:
 	@brief		A STDLogSink that colorizes "warning" or "error" keywords
 	@ingroup	liblog
  */
-class ColoredSTDLogSink : public STDLogSink
+class EXPORT_SYMBOL ColoredSTDLogSink : public STDLogSink
 {
 public:
 	ColoredSTDLogSink(Severity min_severity = Severity::VERBOSE);
@@ -171,7 +176,7 @@ protected:
 	@brief 		A log sink writing to a FILE* file handle
 	@ingroup	liblog
  */
-class FILELogSink : public LogSink
+class EXPORT_SYMBOL FILELogSink : public LogSink
 {
 public:
 	FILELogSink(FILE *f, bool line_buffered = false, Severity min_severity = Severity::VERBOSE);
@@ -184,9 +189,9 @@ protected:
 	FILE		*m_file;
 };
 
-extern std::mutex g_log_mutex;
-extern std::vector<std::unique_ptr<LogSink>> g_log_sinks;
-extern std::set<std::string> g_trace_filters;
+extern IMPORT_SYMBOL std::mutex g_log_mutex;
+extern IMPORT_SYMBOL std::vector<std::unique_ptr<LogSink>> g_log_sinks;
+extern IMPORT_SYMBOL std::set<std::string> g_trace_filters;
 
 /**
 	@brief		RAII wrapper for log indentation
@@ -194,7 +199,7 @@ extern std::set<std::string> g_trace_filters;
 
 	Log messages are indented once for each LogIndenter object in the call stack.
  */
-class LogIndenter
+class EXPORT_SYMBOL LogIndenter
 {
 public:
 	LogIndenter();
@@ -206,7 +211,7 @@ public:
 	@brief		Helper function for parsing arguments that use common syntax
 	@ingroup	liblog
  */
-bool ParseLoggerArguments(
+bool EXPORT_SYMBOL ParseLoggerArguments(
 	int& i,
 	int argc,
 	char* argv[],
@@ -245,16 +250,16 @@ bool ParseLoggerArguments(
 #define LogTrace(...) LogDebugTrace(__func__, __VA_ARGS__)
 #endif
 
-ATTR_FORMAT(1, 2) void LogVerbose(const char *format, ...);
-ATTR_FORMAT(1, 2) void LogNotice(const char *format, ...);
-ATTR_FORMAT(1, 2) void LogWarning(const char *format, ...);
-ATTR_FORMAT(1, 2) void LogError(const char *format, ...);
-ATTR_FORMAT(1, 2) void LogDebug(const char *format, ...);
-ATTR_FORMAT(2, 3) void LogDebugTrace(const char* function, const char *format, ...);
-ATTR_FORMAT(1, 2) ATTR_NORETURN void LogFatal(const char *format, ...);
+ATTR_FORMAT(1, 2) EXPORT_SYMBOL void LogVerbose(const char *format, ...);
+ATTR_FORMAT(1, 2) EXPORT_SYMBOL void LogNotice(const char *format, ...);
+ATTR_FORMAT(1, 2) EXPORT_SYMBOL void LogWarning(const char *format, ...);
+ATTR_FORMAT(1, 2) EXPORT_SYMBOL void LogError(const char *format, ...);
+ATTR_FORMAT(1, 2) EXPORT_SYMBOL void LogDebug(const char *format, ...);
+ATTR_FORMAT(2, 3) EXPORT_SYMBOL void LogDebugTrace(const char *function, const char *format, ...);
+ATTR_FORMAT(1, 2) EXPORT_SYMBOL ATTR_NORETURN void LogFatal(const char *format, ...);
 
 ///Just print the message at given log level, don't do anything special for warnings or errors
-ATTR_FORMAT(2, 3) void Log(Severity severity, const char *format, ...);
+ATTR_FORMAT(2, 3) EXPORT_SYMBOL void Log(Severity severity, const char *format, ...);
 
 #undef ATTR_FORMAT
 #undef ATTR_NORETURN

--- a/log.h
+++ b/log.h
@@ -219,11 +219,15 @@ bool ParseLoggerArguments(
 #else
 #define ATTR_FORMAT(n, m) __attribute__((__format__ (__printf__, n, m)))
 #endif
+#define ATTR_NORETURN_PRE
 #define ATTR_NORETURN     __attribute__((noreturn))
 #else
-//FIXME on MSVC/Windows
+#if _MSC_VER
+// FIXME - doesn't seem to be any equivalent to __attribute__((__format__())) in MSVC
 #define ATTR_FORMAT(n, m)
+#define ATTR_NORETURN_PRE __declspec(noreturn)
 #define ATTR_NORETURN
+#endif
 #endif
 
 /**


### PR DESCRIPTION
commit c010d02ce2157f069ef12cb7410a8c08e79065e6 adds the equivalent `__attribute__((noreturn))` function decorator in MSVC.

commit a4367b11d10477b75c1f541ebf700dae008a055e is more involved, adding MSVC function decorators to support importing and exporting symbols.  By default in shared libraries when built using MSVC, no symbols are exported, and symbols must be explicitly marked `__declspec(dllexport)`. Additionally, global variables must be explicitly imported using `__declspec(dllimport)` placed immediately after an `extern` before the variable type (functions are implicitly imported). This is required to link logtools built using MSVC on Windows as a shared object (DLL).  Should not affect building using GCC/CLANG as it's `#ifdef`-gated behind `_MSC_VER`. Would like someone to review this one if possible?